### PR TITLE
libgpg-erro: add riscv support

### DIFF
--- a/recipes-support/libgpg-error/files/0001-syscfg-Add-a-riscv64-architecture.patch
+++ b/recipes-support/libgpg-error/files/0001-syscfg-Add-a-riscv64-architecture.patch
@@ -1,0 +1,67 @@
+From 596c0d701edeb45e0069bb74b9343e3d5b708ef0 Mon Sep 17 00:00:00 2001
+From: NIIBE Yutaka <gniibe@fsij.org>
+Date: Wed, 28 Feb 2018 10:47:51 +0900
+Subject: [PATCH 1/1] syscfg: Add a riscv64 architecture.
+
+* src/syscfg/lock-obj-pub.riscv64-unknown-linux-gnu.h: New.
+* src/Makefile.am (lock_obj_pub): Add it.
+--
+
+Debian-bug-id: 891663
+Co-authored-by: Karsten Merker <merker@debian.org>
+Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+
+Upstream-Status: Backport
+Signed-off-by: Mirza Krak <mirza.krak@endian.se>
+---
+ src/Makefile.am                                    |  1 +
+ .../lock-obj-pub.riscv64-unknown-linux-gnu.h       | 25 ++++++++++++++++++++++
+ 2 files changed, 26 insertions(+)
+ create mode 100644 src/syscfg/lock-obj-pub.riscv64-unknown-linux-gnu.h
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 4446612..268c2ab 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -65,6 +65,7 @@ lock_obj_pub = \
+         syscfg/lock-obj-pub.powerpc64-unknown-linux-gnu.h   \
+ 	syscfg/lock-obj-pub.powerpc64le-unknown-linux-gnu.h \
+ 	syscfg/lock-obj-pub.powerpc-unknown-linux-gnuspe.h  \
++	syscfg/lock-obj-pub.riscv64-unknown-linux-gnu.h     \
+         syscfg/lock-obj-pub.s390x-ibm-linux-gnu.h           \
+         syscfg/lock-obj-pub.sh3-unknown-linux-gnu.h         \
+         syscfg/lock-obj-pub.sh4-unknown-linux-gnu.h         \
+diff --git a/src/syscfg/lock-obj-pub.riscv64-unknown-linux-gnu.h b/src/syscfg/lock-obj-pub.riscv64-unknown-linux-gnu.h
+new file mode 100644
+index 0000000..8aab9d6
+--- /dev/null
++++ b/src/syscfg/lock-obj-pub.riscv64-unknown-linux-gnu.h
+@@ -0,0 +1,25 @@
++## lock-obj-pub.riscv64-unknown-linux-gnu.h
++## File created by gen-posix-lock-obj - DO NOT EDIT
++## To be included by mkheader into gpg-error.h
++
++typedef struct
++{
++  long _vers;
++  union {
++    volatile char _priv[40];
++    long _x_align;
++    long *_xp_align;
++  } u;
++} gpgrt_lock_t;
++
++#define GPGRT_LOCK_INITIALIZER {1,{{0,0,0,0,0,0,0,0, \
++                                    0,0,0,0,0,0,0,0, \
++                                    0,0,0,0,0,0,0,0, \
++                                    0,0,0,0,0,0,0,0, \
++                                    0,0,0,0,0,0,0,0}}}
++##
++## Local Variables:
++## mode: c
++## buffer-read-only: t
++## End:
++##
+--
+2.11.0
+

--- a/recipes-support/libgpg-error/libgpg-error_1.27.bbappend
+++ b/recipes-support/libgpg-error/libgpg-error_1.27.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-syscfg-Add-a-riscv64-architecture.patch"


### PR DESCRIPTION
Backported patch from upstream

Signed-off-by: Mirza Krak <mirza.krak@endian.se>